### PR TITLE
API: Parsear y devolver status del arduino

### DIFF
--- a/server/popos/parse_status_bytes.py
+++ b/server/popos/parse_status_bytes.py
@@ -1,0 +1,33 @@
+class ParseStatusBytes():
+    @classmethod
+    def parse(cls, status):
+        return [
+            self.device_state(status[0]),
+            self.error_state(status[1])
+        ]
+    
+    @classmethod
+    def isvalid(cls, error):
+        return error == 0
+
+    @classmethod
+    def device_state(cls, status):
+        {
+            "0": "standby",
+            "1": "enfriando",
+            "2": "calentando",
+            "3": "temperatura en modo frio alcanzada",
+            "4": "temperatura en modo calor alcanzada",
+        }[str(status)]
+    
+    @classmethod
+    def error_state(cls, error):
+        {
+            "1": "falla en termistor 1"
+            "2": "falla en termistor 2"
+            "3": "desvio entre termistores"
+            "4": "falla en calibracion"
+            "5": "falla en los rpm del fan del water cooling"
+            "6": "temperatura limite superior superada"
+            "7": "temperatura limite inferior superada"
+        }[str(error)]

--- a/server/popos/status_descriptions.json
+++ b/server/popos/status_descriptions.json
@@ -1,0 +1,19 @@
+{
+    "status": {
+        "0": "Standby",
+        "1": "Cooling",
+        "2": "Heating",
+        "3": "Cold mode goal temperature reached",
+        "4": "Hot mode goal temperature reached"
+    },
+    "errors": {
+        "0": "Device is OK",
+        "1": "Thermistor 1 failed",
+        "2": "Thermistor 2 failed",
+        "3": "Temperature difference between thermistors detected",
+        "4": "Calibration failure",
+        "5": "Water cooler radiator fan failed",
+        "6": "Upper temperature out of range",
+        "7": "Lower temperature out of range"
+    }
+}

--- a/server/popos/status_parser.py
+++ b/server/popos/status_parser.py
@@ -1,4 +1,4 @@
-class ParseStatusBytes():
+class StatusParser():
     @classmethod
     def parse(cls, status):
         return [

--- a/server/popos/status_parser.py
+++ b/server/popos/status_parser.py
@@ -1,9 +1,15 @@
+import json
+
 class StatusParser():
+    with open('server/popos/status_descriptions.json') as json_file:
+        descriptions = json.load(json_file)
+    status_descriptions = descriptions["status"]
+    errors_descriptions = descriptions["errors"]
     @classmethod
     def parse(cls, status):
         return [
-            self.device_state(status[0]),
-            self.error_state(status[1])
+            cls.device_state(str(status[0])),
+            cls.error_state(str(status[1]))
         ]
     
     @classmethod
@@ -12,22 +18,8 @@ class StatusParser():
 
     @classmethod
     def device_state(cls, status):
-        {
-            "0": "standby",
-            "1": "enfriando",
-            "2": "calentando",
-            "3": "temperatura en modo frio alcanzada",
-            "4": "temperatura en modo calor alcanzada",
-        }[str(status)]
+        return StatusParser.status_descriptions[str(status)]
     
     @classmethod
     def error_state(cls, error):
-        {
-            "1": "falla en termistor 1"
-            "2": "falla en termistor 2"
-            "3": "desvio entre termistores"
-            "4": "falla en calibracion"
-            "5": "falla en los rpm del fan del water cooling"
-            "6": "temperatura limite superior superada"
-            "7": "temperatura limite inferior superada"
-        }[str(error)]
+        return StatusParser.errors_descriptions[str(error)]


### PR DESCRIPTION
Ahora el endpoint root en vez de mandar un string hardcodeado devuelve un dict con info general de la API:
```
{
    "device": "COM3",
    "last_measurement": 15.82720947265625,
    "operation_mode": "cold",
    "status_codes": {
        "error": 0,
        "status": 1
    },
    "status_descriptions": {
        "error": "Device is OK",
        "status": "Cooling"
    },
    "target_temperature": 15,
    "time_since_last_measurement": 10.188000000000102
}
```
Tambien se puede pedir esta info desde el endpoint de medicion de la temperatura agregando la variable de ruta consumer: `/read_temperature?consumer=UI`