### PR TITLE
Mostrar el error en una ventana

### DIFF
--- a/interface/flaskRequests.py
+++ b/interface/flaskRequests.py
@@ -28,7 +28,7 @@ def stopTemp():
 
 def readTemperature():
     r=requests.get( serverUrl + "read_temperature?consumer=UI")
-    if not r.status_code == 200: return "ServerError"
+    if not r.status_code == 200: return {"error": "ServerError"}
     r=r.json()
     return r
 
@@ -37,5 +37,5 @@ def shutdownServer():
 
 def apiStatus():
     r = requests.get(serverUrl)
-    if not r.status_code == 200: return "ServerError"
+    if not r.status_code == 200: return {"error": "ServerError"}
     return r.json()

--- a/interface/mainWindow.py
+++ b/interface/mainWindow.py
@@ -60,7 +60,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_mainWindow):
         
     def updateTemperature(self):
         response = flaskRequests.readTemperature()
-        if response == "ServerError": return self.communicationError()
+        if response.get("error") == "ServerError": return self.communicationError()
         newTemp = float(response["temperature"])
         target_temp = response.get("status", {}).get("target_temperature")
         target_temp = float(target_temp) if not target_temp == None else -99
@@ -94,6 +94,10 @@ class MainWindow(QtWidgets.QMainWindow, Ui_mainWindow):
         if not status_error == 0:
             self.StatusIcon.setPixmap(QtGui.QPixmap(":/icons/danger.png"))
             self.measurementTimer.stop()
+            self.errDialog.errorDiagInfoLabel.setText(status.get("status_descriptions", {}).get("error"))
+            self.errDialog.exec_()
+            flaskRequests.closeDevice(self.device)
+            self.close()
 
     def updateGraph(self,temperature: float, target_temp=25.0):
         maximumTimeInterval=30
@@ -130,6 +134,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_mainWindow):
                 else:
                     flaskRequests.closeDevice(self.device)
                     self.device = {}
+                    self.errDialog.errorDiagInfoLabel.setText("Device not found at selected port.")
                     self.errDialog.exec_()
 
     

--- a/server/flask_server.py
+++ b/server/flask_server.py
@@ -75,7 +75,7 @@ def get_temperature():
 @app.route('/restart_timer', methods=['POST'])
 def restart_timer():
     SerialConnection.reference_time = time.monotonic()
-    return jsonify({ "message": "Successfuly restarted timer"), 200
+    return jsonify({ "message": "Successfuly restarted timer" }), 200
 
 @app.route('/cold', methods=['POST'])
 def cold():
@@ -110,12 +110,12 @@ def error_clear():
     return '', 202
 
 def temperature_out_of_range(request):
-    if 10 <= float(request.json["objective_temperature"]) <= 50:
+    if 10 <= float(request.json["objective_temperature"]) <= 40:
         return False
     return True
 
 def invalid_temperature():
-    return jsonify({"error": "Invalid temperature. It must be between 10 and 50"}), 400
+    return jsonify({"error": "Invalid temperature. It must be between 10 and 40"}), 400
 
 def api_status():
     return {

--- a/server/popos/commander.py
+++ b/server/popos/commander.py
@@ -46,7 +46,9 @@ class Commander():
                     Commander.connection = None
                     return 404
                 try:
-                    self.status()
+                    device_response = self.status()
+                    if not device_response[0] == 0:
+                        raise Exception("Incorrect device")
                 except Exception as e:
                     Commander.logger.info('Selected device is invalid: %s', p.device)
                     Commander.logger.info(e)
@@ -135,13 +137,11 @@ class Command():
 
     def send_chunk(self, serial_connection, data):
         raw_data = struct.pack(self.send_data_format, self.serial_identifier, *data)
-        Commander.logger.info(raw_data)
         serial_connection.write(raw_data)
         return True
 
     def read_chunk(self, serial_connection):
         raw_data = serial_connection.read(self.receive_data_buffer_size)
-        Commander.logger.info(raw_data)
         return list(struct.unpack(self.receive_data_format, raw_data))
 
     def perform(self, serial_connection, data):


### PR DESCRIPTION
Cuando el dispositivo informa un error, ademas de cambiar el indicador a rojo, abre una ventana mostrando la descripcion del error.
Arregla algunos bugs:

- Cuando se conectaba con el dispositivo incorrecto, el Commander levantaba una excepcion por mala logica.
- Cuando el endpoint de status devuelve un error, el archivo flask_requests devolvia un string en lugar de un dict.
- Faltaba una llave en flask_server