### PR TITLE
En caso de exito devolver status code 200

### DIFF
--- a/examples/exampleParadigm.m
+++ b/examples/exampleParadigm.m
@@ -1,37 +1,6 @@
 clear
 clc
-% import lib
-classdef lib % Class lib can be moved to another file
-   methods
-      function r = SetTempCold(obj, temp)
-            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct('temperature', temp); % temp must be int or float
-            uri = 'http://127.0.0.1:5000/cold';
-            r = webwrite(uri, body, opts);
-      end
-      function r = SetTempHot(obj, temp)
-            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct('temperature', string(temp)); % temp must be int or float
-            uri = 'http://127.0.0.1:5000/hot';
-            r = webwrite(uri, body, opts);
-      end
-      function r = GetTemperature(obj)
-            uri = 'http://127.0.0.1:5000/temperature_test';
-            resp = webread(uri);
-            r = [str2double(resp.temperature), str2double(resp.time)];
-      end
-      function r = RestartTimer(obj)
-            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct();
-            uri = 'http://127.0.0.1:5000/restart_timer';
-            webwrite(uri, body, opts);
-      end
-      function r = Status(obj)
-            uri = 'http://127.0.0.1:5000/';
-            r = webread(uri);
-      end            
-   end
-end
+import lib
 a = lib;
 
 Ts = 0.5; % sec
@@ -40,7 +9,7 @@ y = zeros(2, 1);
 index = 1;
 
 a.SetTempCold(15);
-objectiveTemperatureReached = false
+objectiveTemperatureReached = false;
 
 % while(objectiveTemperatureReached) % Leaving this purposefuly commented until arduino implements it
 %     status = a.Status()
@@ -54,12 +23,13 @@ xlabel('Time [s]')
 ylabel('Temperature [C]')
 grid on
 xlim([0 25])
-ylim([0 30])
+ylim([0 60])
 p.XDataSource = 'x';
 p.YDataSource = 'y';
 
 a.RestartTimer()
-while(time < 20)
+time = 0;
+while(time < 5)
     [temp, time] = a.GetTemperature();
     x(index) = time;
     y(index) = temp;
@@ -68,3 +38,4 @@ while(time < 20)
     drawnow
     pause(Ts);
 end
+a.Stop()

--- a/examples/exampleParadigm.m
+++ b/examples/exampleParadigm.m
@@ -1,15 +1,53 @@
 clear
 clc
-import lib
+% import lib
+classdef lib % Class lib can be moved to another file
+   methods
+      function r = SetTempCold(obj, temp)
+            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
+            body = struct('temperature', temp); % temp must be int or float
+            uri = 'http://127.0.0.1:5000/cold';
+            r = webwrite(uri, body, opts);
+      end
+      function r = SetTempHot(obj, temp)
+            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
+            body = struct('temperature', string(temp)); % temp must be int or float
+            uri = 'http://127.0.0.1:5000/hot';
+            r = webwrite(uri, body, opts);
+      end
+      function r = GetTemperature(obj)
+            uri = 'http://127.0.0.1:5000/temperature_test';
+            resp = webread(uri);
+            r = [str2double(resp.temperature), str2double(resp.time)];
+      end
+      function r = RestartTimer(obj)
+            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
+            body = struct();
+            uri = 'http://127.0.0.1:5000/restart_timer';
+            webwrite(uri, body, opts);
+      end
+      function r = Status(obj)
+            uri = 'http://127.0.0.1:5000/';
+            r = webread(uri);
+      end            
+   end
+end
 a = lib;
 
 Ts = 0.5; % sec
-Ns = 100;
 x = zeros(2, 1);
 y = zeros(2, 1);
 index = 1;
 
-a.SetTemperature(10);
+a.SetTempCold(15);
+objectiveTemperatureReached = false
+
+% while(objectiveTemperatureReached) % Leaving this purposefuly commented until arduino implements it
+%     status = a.Status()
+%     if (status.status_codes[1] == 2) || (status.status_codes[1] == 4)
+%         objectiveTemperatureReached = status.status_codes[1]
+%     end
+% end
 
 p = plot(x, y);
 xlabel('Time [s]')
@@ -20,10 +58,9 @@ ylim([0 30])
 p.XDataSource = 'x';
 p.YDataSource = 'y';
 
-time = 0;
+a.RestartTimer()
 while(time < 20)
-    temp = a.GetTemperature();
-    time = Ts * index;
+    [temp, time] = a.GetTemperature();
     x(index) = time;
     y(index) = temp;
     index = index + 1;

--- a/examples/lib.m
+++ b/examples/lib.m
@@ -2,20 +2,27 @@ classdef lib
    methods
       function r = SetTempCold(obj, temp)
             opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct('temperature', temp); % temp must be int or float
+            body = struct('objective_temperature', temp); % temp must be int or float
             uri = 'http://127.0.0.1:5000/cold';
             r = webwrite(uri, body, opts);
       end
       function r = SetTempHot(obj, temp)
             opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct('temperature', string(temp)); % temp must be int or float
+            body = struct('objective_temperature', string(temp)); % temp must be int or float
             uri = 'http://127.0.0.1:5000/hot';
             r = webwrite(uri, body, opts);
       end
-      function r = GetTemperature(obj)
-            uri = 'http://127.0.0.1:5000/temperature_test';
+      function r = Stop(obj)
+            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
+            body = struct();
+            uri = 'http://127.0.0.1:5000/stop_device';
+            r = webwrite(uri, body, opts);
+      end
+      function [temp, time] = GetTemperature(obj)
+            uri = 'http://127.0.0.1:5000/read_temperature';
             resp = webread(uri);
-            r = [str2double(resp.temperature), str2double(resp.time)];
+            temp = resp.temperature;
+            time = resp.time;
       end
       function r = RestartTimer(obj)
             opts = weboptions('RequestMethod','post', 'MediaType','application/json');

--- a/examples/lib.m
+++ b/examples/lib.m
@@ -1,26 +1,31 @@
 classdef lib
    methods
-      function r = GetDevices(obj)
-            uri = 'http://127.0.0.1:5000/list_devices';
-            r = webread(uri);
-      end
-      function r = ConnectDevice(obj, device)
+      function r = SetTempCold(obj, temp)
             opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct('device', device);
-            uri = 'http://127.0.0.1:5000/open_connection';
+            body = struct('temperature', temp); % temp must be int or float
+            uri = 'http://127.0.0.1:5000/cold';
             r = webwrite(uri, body, opts);
       end
-      function r = SetTemperature(obj, temp)
+      function r = SetTempHot(obj, temp)
             opts = weboptions('RequestMethod','post', 'MediaType','application/json');
-            body = struct('temperature', string(temp));
-            uri = 'http://127.0.0.1:5000/temperature_test';
+            body = struct('temperature', string(temp)); % temp must be int or float
+            uri = 'http://127.0.0.1:5000/hot';
             r = webwrite(uri, body, opts);
       end
       function r = GetTemperature(obj)
             uri = 'http://127.0.0.1:5000/temperature_test';
             resp = webread(uri);
-            r = str2double(resp.temperature);
+            r = [str2double(resp.temperature), str2double(resp.time)];
       end
+      function r = RestartTimer(obj)
+            opts = weboptions('RequestMethod','post', 'MediaType','application/json');
+            body = struct();
+            uri = 'http://127.0.0.1:5000/restart_timer';
+            webwrite(uri, body, opts);
+      end
+      function r = Status(obj)
+            uri = 'http://127.0.0.1:5000/';
+            r = webread(uri);
+      end            
    end
 end
-

--- a/server/flask_server.py
+++ b/server/flask_server.py
@@ -66,7 +66,7 @@ def get_temperature():
     start_time = time.monotonic() - SerialConnection.reference_time
     if not SerialConnection.connection_available: return no_connection()
     temperature = SerialConnection.read_temperature()
-    response = { "temperature": str(temperature) }
+    response = { "temperature": temperature }
     if request.args.get('consumer') == "UI": response["status"] = api_status()
     finish_time = time.monotonic() - SerialConnection.reference_time
     response["time"] = (finish_time + start_time)/2

--- a/server/flask_server.py
+++ b/server/flask_server.py
@@ -58,7 +58,7 @@ def close_connection():
     if "error" in response: # TODO this if is falopa
         status = 400
     else:
-        status = 202
+        status = 200
     return jsonify(response), status
 
 @app.route('/read_temperature', methods=['GET'])
@@ -82,32 +82,32 @@ def cold():
     if not SerialConnection.connection_available: return no_connection()
     if temperature_out_of_range(request): return invalid_temperature()
     SerialConnection.cold(request.json["objective_temperature"])
-    return '', 202
+    return '', 200
 
 @app.route('/hot', methods=['POST'])
 def hot():
     if not SerialConnection.connection_available: return no_connection()
     if temperature_out_of_range(request): return invalid_temperature()
     SerialConnection.hot(request.json["objective_temperature"])
-    return '', 202
+    return '', 200
 
 @app.route('/stop_device', methods=['POST'])
 def stop_device():
     if not SerialConnection.connection_available: return no_connection()
     SerialConnection.stop()
-    return '', 202
+    return '', 200
 
 @app.route('/error', methods=['POST'])
 def error():
     if not SerialConnection.connection_available: return no_connection()
     SerialConnection.error_set(request.json["error"])
-    return '', 202
+    return '', 200
 
 @app.route('/error_clear', methods=['POST'])
 def error_clear():
     if not SerialConnection.connection_available: return no_connection()
     SerialConnection.error_clear()
-    return '', 202
+    return '', 200
 
 def temperature_out_of_range(request):
     if 10 <= float(request.json["objective_temperature"]) <= 40:


### PR DESCRIPTION
Es mucho mas facil de implementar el paradigma en matlab si el status code de exito es 200 para todos los casos, ya que matlab levanta un error y corta la ejecucion si la respuesta no tiene status 200,
Falta probarlo